### PR TITLE
Lantern test

### DIFF
--- a/src/MagnumExternal/TinyGltf/tiny_gltf.h
+++ b/src/MagnumExternal/TinyGltf/tiny_gltf.h
@@ -4381,6 +4381,9 @@ static bool ParsePrimitive(Primitive *primitive, Model *model, std::string *err,
   int indices = -1;
   ParseIntegerProperty(&indices, err, o, "indices", false);
   primitive->indices = indices;
+  if (err) {
+    (*err) += "indices: " + std::to_string(indices) + "\n";
+  }
   if (!ParseStringIntegerProperty(&primitive->attributes, err, o, "attributes",
                                   true, "Primitive")) {
     return false;
@@ -4438,6 +4441,10 @@ static bool ParsePrimitive(Primitive *primitive, Model *model, std::string *err,
   (void)model;
 #endif
 
+  if (err) {
+    (*err) += "primitive->indices: " + std::to_string(primitive->indices) + "\n";
+  }
+
   return true;
 }
 
@@ -4461,6 +4468,12 @@ static bool ParseMesh(Mesh *mesh, Model *model, std::string *err, const json &o,
     }
   }
 
+  if (mesh->primitives.size()) {
+    if (err) {
+      (*err) += "mesh->primitives.back().indices: " + std::to_string(mesh->primitives.back().indices) + "\n";
+    }
+  }    
+
   // Should probably check if has targets and if dimensions fit
   ParseNumberArrayProperty(&mesh->weights, err, o, "weights", false);
 
@@ -4481,6 +4494,12 @@ static bool ParseMesh(Mesh *mesh, Model *model, std::string *err, const json &o,
       }
     }
   }
+
+  if (mesh->primitives.size()) {
+    if (err) {
+      (*err) += "2 mesh->primitives.back().indices: " + std::to_string(mesh->primitives.back().indices) + "\n";
+    }
+  }    
 
   return true;
 }
@@ -5516,6 +5535,11 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
       }
 
       model->meshes.emplace_back(std::move(mesh));
+
+      if (err) {
+        (*err) += "model->meshes.back().primitives.back().indices: " + std::to_string(model->meshes.back().primitives.back().indices) + "\n";
+      }
+
       return true;
     });
 
@@ -5524,14 +5548,31 @@ bool TinyGLTF::LoadFromString(Model *model, std::string *err, std::string *warn,
     }
   }
 
+  if (err) {
+    (*err) += "2 model->meshes.back().primitives.back().indices: " + std::to_string(model->meshes.back().primitives.back().indices) + "\n";
+  }
+
   // Assign missing bufferView target types
   // - Look for missing Mesh indices
   // - Look for missing bufferView targets
   for (auto &mesh : model->meshes) {
+
+    if (err) {
+      (*err) += "mesh.primitives.back().indices: " + std::to_string(mesh.primitives.back().indices) + "\n";
+    }
+
     for (auto &primitive : mesh.primitives) {
+
+      if (err) {
+        (*err) += "primitive.indices: " + std::to_string(primitive.indices) + "\n";
+      }
+
       if (primitive.indices >
           -1)  // has indices from parsing step, must be Element Array Buffer
       {
+        (*err) += "size_t(primitive.indices): " + std::to_string(size_t(primitive.indices)) + "\n";
+        (*err) += "model->accessors.size(): " + std::to_string(model->accessors.size()) + "\n";
+
         if (size_t(primitive.indices) >= model->accessors.size()) {
           if (err) {
             (*err) += "primitive indices accessor out of bounds";

--- a/src/MagnumPlugins/TinyGltfImporter/CMakeLists.txt
+++ b/src/MagnumPlugins/TinyGltfImporter/CMakeLists.txt
@@ -92,8 +92,11 @@ if(MAGNUM_TINYGLTFIMPORTER_BUILD_STATIC)
     target_sources(TinyGltfImporter INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/importStaticPlugin.cpp)
 endif()
 
-if(BUILD_TESTS)
+# if(BUILD_TESTS)
+if (1)
     add_subdirectory(Test)
+else()
+    message( FATAL_ERROR "not building TinyGltfImporter test!" )
 endif()
 
 # MagnumPlugins TinyGltfImporter target alias for superprojects

--- a/src/MagnumPlugins/TinyGltfImporter/Test/CMakeLists.txt
+++ b/src/MagnumPlugins/TinyGltfImporter/Test/CMakeLists.txt
@@ -126,6 +126,7 @@ corrade_add_test(TinyGltfImporterTest
         přívodní-šňůra.png
         scene.gltf
         scene.glb
+        Lantern.glb
         scene-nodefault.gltf
         scene-nodefault.glb
         scene-invalid.gltf

--- a/src/MagnumPlugins/TinyGltfImporter/Test/TinyGltfImporterTest.cpp
+++ b/src/MagnumPlugins/TinyGltfImporter/Test/TinyGltfImporterTest.cpp
@@ -102,6 +102,8 @@ struct TinyGltfImporterTest: TestSuite::Tester {
     void sceneInvalidScene();
     void sceneInvalidDefaultScene();
 
+    void extraScenes();
+
     void objectTransformation();
     void objectTransformationQuaternionNormalizationEnabled();
     void objectTransformationQuaternionNormalizationDisabled();
@@ -476,6 +478,8 @@ TinyGltfImporterTest::TinyGltfImporterTest() {
                        &TinyGltfImporterTest::sceneEmpty,
                        &TinyGltfImporterTest::sceneNoDefault},
                       Containers::arraySize(SingleFileData));
+
+    addTests({&TinyGltfImporterTest::extraScenes});
 
     addTests({&TinyGltfImporterTest::sceneInvalidMesh});
 
@@ -1526,6 +1530,24 @@ void TinyGltfImporterTest::sceneInvalidDefaultScene() {
     CORRADE_VERIFY(!importer->openFile(Utility::Directory::join(TINYGLTFIMPORTER_TEST_DIR,
         "scene-invalid-default.gltf")));
     CORRADE_COMPARE(out.str(), "Trade::TinyGltfImporter::openData(): scene index 0 out of bounds for 0 scenes\n");
+}
+
+void TinyGltfImporterTest::extraScenes() {
+    setTestCaseDescription("extraScenes");
+
+    Containers::Pointer<AbstractImporter> importer = _manager.instantiate("TinyGltfImporter");
+    CORRADE_VERIFY(importer->openFile(Utility::Directory::join(TINYGLTFIMPORTER_TEST_DIR,
+        "Lantern.glb")));
+
+    {
+        auto object = importer->object3D("LanternPole_Body");
+        CORRADE_VERIFY(object);
+        CORRADE_VERIFY(object->importerState());
+        CORRADE_COMPARE(object->instanceType(), ObjectInstanceType3D::Mesh);
+        CORRADE_COMPARE(static_cast<MeshObjectData3D&>(*object).material(), 0);
+        CORRADE_COMPARE(static_cast<MeshObjectData3D&>(*object).skin(), -1);
+        CORRADE_VERIFY(object->children().empty());
+    }
 }
 
 void TinyGltfImporterTest::objectTransformation() {

--- a/src/MagnumPlugins/TinyGltfImporter/TinyGltfImporter.cpp
+++ b/src/MagnumPlugins/TinyGltfImporter/TinyGltfImporter.cpp
@@ -325,6 +325,8 @@ void TinyGltfImporter::doOpenData(const Containers::ArrayView<const char> data) 
         Error{} << "Trade::TinyGltfImporter::openData(): error opening file:" << err;
         doClose();
         return;
+    } else {
+      Error{} << "Trade::TinyGltfImporter::openData(): no error but here's the err string: " << err;
     }
 
     /* Bounds checks that can't be deferred to later. No, tinygltf doesn't


### PR DESCRIPTION
This PR is just documenting this branch (do not merge). This branch includes a new test in TinyGltfImporterTest to load Lantern.glb. It also includes some debug code that I've found helpful to debug the Quest2 crash.

The JS version of the test is hosted live [here](https://ericundersander.com/habitat/js_test10/), including custom HTML to only run test 55 (the new `extraScenes` test).

Lantern.glb is [here](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/Lantern/glTF-Binary).

Here's how I compiled with emcc (this is a snippet from habitat build_js.sh, but I guess you can adapt this to just build TinyGltfImporterTest):
```
mkdir -p build_corrade-rc
pushd build_corrade-rc
cmake ../src \
    -DBUILD_GUI_VIEWERS=OFF \
    -DBUILD_PYTHON_BINDINGS=OFF \
    -DBUILD_ASSIMP_SUPPORT=OFF \
    -DBUILD_DATATOOL=OFF \
    -DBUILD_PTEX_SUPPORT=OFF
cmake --build . --target corrade-rc --
popd

mkdir -p build_js
cd build_js

EXE_LINKER_FLAGS="-s USE_WEBGL2=1"
cmake ../src \
    -DCORRADE_RC_EXECUTABLE=../build_corrade-rc/RelWithDebInfo/bin/corrade-rc \
    -DBUILD_GUI_VIEWERS="$( if ${WEB_APPS} ; then echo ON ; else echo OFF; fi )" \
    -DBUILD_PYTHON_BINDINGS=OFF \
    -DBUILD_ASSIMP_SUPPORT=OFF \
    -DBUILD_DATATOOL=OFF \
    -DBUILD_PTEX_SUPPORT=OFF \
    -DCMAKE_BUILD_TYPE=Debug \
    -DCMAKE_PREFIX_PATH="$EMSCRIPTEN" \
    -DCMAKE_TOOLCHAIN_FILE="../src/deps/corrade/toolchains/generic/Emscripten-wasm.cmake" \
    -DCMAKE_INSTALL_PREFIX="." \
    -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
    -DCMAKE_CXX_FLAGS="-s FORCE_FILESYSTEM=1 -s ALLOW_MEMORY_GROWTH=1 -s ASSERTIONS=1 -s SAFE_HEAP=0 -g2 -s DISABLE_EXCEPTION_CATCHING=0" \
    -DCMAKE_EXE_LINKER_FLAGS="${EXE_LINKER_FLAGS}" \
    -DBUILD_WITH_BULLET="$( if ${BULLET} ; then echo ON ; else echo OFF; fi )" \
    -DBUILD_WEB_APPS="$( if ${WEB_APPS} ; then echo ON ; else echo OFF; fi )"
```

Note that a Release build generally crashes with a memory access violation or similar, which I assume is the same issue manifesting slightly differently. If I set SAFE_HEAP=1, it doesn't crash.

Related submodules:
magnum is on commit 360ca834e17870e56f987bb6ecca308ab9889409
corrade is on commit a8065db3c55aec214aa4e4887c4073289b2988e2

Screenshot of this test failing on Quest 2. The exact failure may look different depending on emcc compile options and other factors.
![oculus_tinygltfimportertest_fail](https://user-images.githubusercontent.com/6557808/130162745-e27ca04f-6241-458a-9020-2cc21f0f3faa.jpg)

I also tested on a Samsung s10e and iPhone 11 Pro and the test page loads fine.